### PR TITLE
DEVOPS-1243: Clean up old client entries

### DIFF
--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -139,10 +139,12 @@ Engine.prototype = {
     });
   },
 
-  clientExists:function (clientId, callback, context) {
+  clientExists: function (clientId, callback, context) {
+    var cutoff = new Date().getTime() - (1000 * 1.6 * this._server.timeout);
+
     var redis = this._getShard(clientId).redis;
     redis.zscore(this._ns + '/clients', clientId, function (error, score) {
-      callback.call(context, score !== null);
+      callback.call(context, score > cutoff);
     });
   },
 
@@ -289,6 +291,9 @@ Engine.prototype = {
           redis.publish(self._ns + '/' + clientId + '/notify', clientId);
           self._server.debug('Published for client ? - ? - to server ?', clientId, message, shard.shardName);
         });
+        self.clientExists(clientId, function(exists) {
+          if (!exists) this._redis.del(self._ns + '/clients/' + clientId + '/messages');
+        });
       });
     };
 
@@ -386,4 +391,3 @@ Engine.prototype = {
 };
 
 module.exports = Engine;
-

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -155,27 +155,29 @@ Engine.prototype = {
       subscriber = shard.subscriber;
 
     subscriber.unsubscribe(self._ns + '/' + clientId + '/notify');
-    redis.smembers(this._ns + '/clients/' + clientId + '/channels', function (err, channels) {
-      if (err) {
-        if (callback) callback.call(context);
-        return;
-      }
+    this._redis.zadd(this._ns + '/clients', 0, clientId, function() {
+      redis.smembers(this._ns + '/clients/' + clientId + '/channels', function (err, channels) {
+        if (err) {
+          if (callback) callback.call(context);
+          return;
+        }
 
-      var n = channels.length, i = 0;
-      if (i === n) return self._afterSubscriptionsRemoved(clientId, callback, context);
+        var n = channels.length, i = 0;
+        if (i === n) return self._afterSubscriptionsRemoved(clientId, callback, context);
 
-      var unsubscribeError = null;
-      channels.forEach(function (channel) {
-        self.unsubscribe(clientId, channel, function (err) {
-          unsubscribeError = unsubscribeError || err;
-          i += 1;
-          if (i === n) {
-            if (unsubscribeError) {
-              if (callback) callback.call(context);
-            } else {
-              self._afterSubscriptionsRemoved(clientId, callback, context);
+        var unsubscribeError = null;
+        channels.forEach(function (channel) {
+          self.unsubscribe(clientId, channel, function (err) {
+            unsubscribeError = unsubscribeError || err;
+            i += 1;
+            if (i === n) {
+              if (unsubscribeError) {
+                if (callback) callback.call(context);
+              } else {
+                self._afterSubscriptionsRemoved(clientId, callback, context);
+              }
             }
-          }
+          });
         });
       });
     });

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -155,7 +155,7 @@ Engine.prototype = {
       subscriber = shard.subscriber;
 
     subscriber.unsubscribe(self._ns + '/' + clientId + '/notify');
-    this._redis.zadd(this._ns + '/clients', 0, clientId, function() {
+    redis.zadd(this._ns + '/clients', 0, clientId, function() {
       redis.smembers(this._ns + '/clients/' + clientId + '/channels', function (err, channels) {
         if (err) {
           if (callback) callback.call(context);


### PR DESCRIPTION
Redis memory usage has been steadily increasing since we rolled out sharded Redis for aha-faye-app. Something is not cleaning up after itself.

Changes: delete old client entries once they have aged out

Pulled from https://github.com/faye/faye-redis-node/commit/5cc6fc163357f7e2074082728275bd194b083e6a. ~~I selected just the changes that will delete old client records, not sure we need the other changes from this commit right now.~~ All changes have been added after a discussion with @maeve convinced me that they belong.