### PR TITLE
DEVOPS-1244: Fix sharding bug

### DIFF
--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -294,7 +294,7 @@ Engine.prototype = {
           self._server.debug('Published for client ? - ? - to server ?', clientId, message, shard.shardName);
         });
         self.clientExists(clientId, function(exists) {
-          if (!exists) this._redis.del(self._ns + '/clients/' + clientId + '/messages');
+          if (!exists) redis.del(self._ns + '/clients/' + clientId + '/messages');
         });
       });
     };


### PR DESCRIPTION
The commit we were pulling the memory fix from had its `redis` variable prefixed with an underscore. But our fork of faye-redis-sharded-node` does not. I caught one of these during a staging smoke test, but the second wasn't hit until #1 was deployed to production.

Changes: fix missed underscore removal