### PR TITLE
add ping command to createClient

### DIFF
--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -134,6 +134,7 @@ Engine.prototype = {
     this._getShard(clientId).redis.zadd(this._ns + '/clients', 0, clientId, function (error, added) {
       if (added === 0) return self.createClient(callback, context);
       self._server.debug('Created new client ?', clientId);
+      self.ping(clientId);
       self._server.trigger('handshake', clientId);
       callback.call(context, clientId);
     });


### PR DESCRIPTION
This fixes a problem where the first ping might not arrive before `clientExists` is called for the first time.

In development this causes constant connection thrashing. In production it appears to be contributing to excessive connections, but does not fail so consistently.