### PR TITLE
A-13686: Fix namespace references in faye sharded redis

### DIFF
--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -157,7 +157,7 @@ Engine.prototype = {
 
     subscriber.unsubscribe(self._ns + '/' + clientId + '/notify');
     redis.zadd(this._ns + '/clients', 0, clientId, function() {
-      redis.smembers(this._ns + '/clients/' + clientId + '/channels', function (err, channels) {
+      redis.smembers(self._ns + '/clients/' + clientId + '/channels', function (err, channels) {
         if (err) {
           if (callback) callback.call(context);
           return;
@@ -340,7 +340,7 @@ Engine.prototype = {
         var cutoff = new Date().getTime() - 1000 * 2 * timeout,
           self = this;
 
-        shard.redis.zrangebyscore(this._ns + '/clients', 0, cutoff, function (error, clients) {
+        shard.redis.zrangebyscore(self._ns + '/clients', 0, cutoff, function (error, clients) {
           if (error) return releaseLock();
 
           var i = 0, n = clients.length;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description":"Redis backend engine for Faye with support for sharding",
   "author":"Myspace",
   "keywords":["faye", "faye-redis", "pubsub", "bayeux"],
-  "version":"0.2.5",
+  "version":"0.2.6",
   "engines":{
     "node":">=0.4.0"
   },


### PR DESCRIPTION
The wrong `this` was being used, so that subscribed channels are not being cleaned up after use. This was causing the server to do more and more work processing all of the channels, leading to 100% CPU utilization in the shard redis instances.