### PR TITLE
DEVOPS-1737: Add logging to troubleshoot faye/redis/sharding issue

### DIFF
--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -402,7 +402,7 @@ Engine.prototype = {
   // This is focused debug logging, specifically to troubleshoot process-killing errors in clientExists.
   // If the value is undefined, then log some info and return the first shard's Redis.
   _getRedis: function (clientId, context) {
-    sentry.logInfo(`clientId: ${clientId}`);
+    sentry.logMessage(`clientId: ${clientId}`);
     if (clientId !== undefined)
       return this._getShard(clientId).redis; // This is the original code from clientExists
 

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -408,10 +408,10 @@ Engine.prototype = {
     console.log(context);
     console.log("Stack trace:")
     console.trace();
-    console.log("Info: return default shard's Redis")
+    console.log("Info: returning default shard's Redis");
     const shards = this._shardManagers[0]._shards;
     if (shards?.length || 0 === 0)
-      throw "Unable to find default shard"; // Should never happen, but better safe than sorry
+      throw "Unable to find default shard"; // Safety check: this should never happen
 
     return shards[Object.keys(shards)[0]].redis;
   }

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -1,6 +1,8 @@
 var redis = require('redis'),
   ShardManager = require('./sharding/shard-manager');
 
+const sentry = require('../../../src/util/sentry');
+
 var Engine = function (server, options) {
   var self = this;
   this._server = server;
@@ -400,20 +402,24 @@ Engine.prototype = {
   // This is focused debug logging, specifically to troubleshoot process-killing errors in clientExists.
   // If the value is undefined, then log some info and return the first shard's Redis.
   _getRedis: function (clientId, context) {
+    sentry.logInfo(`clientId: ${clientId}`);
     if (clientId !== undefined)
       return this._getShard(clientId).redis; // This is the original code from clientExists
 
     // Try to get more information on when/why we're missing clientId by dumping the context
-    console.log("Warning: clientId is undefined, context is:");
-    console.log(context);
-    console.log("Stack trace:")
-    console.trace();
-    console.log("Info: returning default shard's Redis");
-    const shards = this._shardManagers[0]._shards;
-    if (shards?.length || 0 === 0)
-      throw "Unable to find default shard"; // Safety check: this should never happen
+    try {
+      const msg = `clientId is undefined, context is: ${context}`;
+      console.warn(msg);
+      sentry.logError(new Error(msg));
+    }
+    finally {
+      console.info("Returning default shard's Redis");
+      const shards = this._shardManagers[0]._shards;
+      if (shards?.length || 0 === 0)
+        throw "Unable to find default shard"; // Safety check: this should never happen
 
-    return shards[Object.keys(shards)[0]].redis;
+      return shards[Object.keys(shards)[0]].redis;
+    }
   }
 };
 

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -143,7 +143,11 @@ Engine.prototype = {
   clientExists: function (clientId, callback, context) {
     var cutoff = new Date().getTime() - (1000 * 1.6 * this._server.timeout);
 
-    var redis = this._getShard(clientId).redis;
+    // var redis = this._getShard(clientId).redis;
+    // Replace the original code above with something more robust
+    // and that provides more info when clientId is undefined
+    var redis = this._getRedis(clientId, context);
+
     redis.zscore(this._ns + '/clients', clientId, function (error, score) {
       callback.call(context, score > cutoff);
     });
@@ -390,6 +394,26 @@ Engine.prototype = {
   _getShard:function (key, shardManager) {
     var manager = shardManager || this._shardManagers[0];
     return manager.getShard(key);
+  },
+
+  // Returns the Redis for a given clientId's shard.
+  // This is focused debug logging, specifically to troubleshoot process-killing errors in clientExists.
+  // If the value is undefined, then log some info and return the first shard's Redis.
+  _getRedis: function (clientId, context) {
+    if (clientId !== undefined)
+      return this._getShard(clientId).redis; // This is the original code from clientExists
+
+    // Try to get more information on when/why we're missing clientId by dumping the context
+    console.log("Warning: clientId is undefined, context is:");
+    console.log(context);
+    console.log("Stack trace:")
+    console.trace();
+    console.log("Info: return default shard's Redis")
+    const shards = this._shardManagers[0]._shards;
+    if (shards?.length || 0 === 0)
+      throw "Unable to find default shard"; // Should never happen, but better safe than sorry
+
+    return shards[Object.keys(shards)[0]].redis;
   }
 };
 

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -402,7 +402,6 @@ Engine.prototype = {
   // This is focused debug logging, specifically to troubleshoot process-killing errors in clientExists.
   // If the value is undefined, then log some info and return the first shard's Redis.
   _getRedis: function (clientId, context) {
-    sentry.logMessage(`clientId: ${clientId}`);
     if (clientId !== undefined)
       return this._getShard(clientId).redis; // This is the original code from clientExists
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description":"Redis backend engine for Faye with support for sharding",
   "author":"Myspace",
   "keywords":["faye", "faye-redis", "pubsub", "bayeux"],
-  "version":"0.2.7-DEVOPS-1737.1",
+  "version":"0.2.7",
   "engines":{
     "node":">=0.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description":"Redis backend engine for Faye with support for sharding",
   "author":"Myspace",
   "keywords":["faye", "faye-redis", "pubsub", "bayeux"],
-  "version":"0.2.6",
+  "version":"0.2.7-DEVOPS-1737.1",
   "engines":{
     "node":">=0.4.0"
   },


### PR DESCRIPTION
We've been seeing aha-faye-app containers dying lately after turning on alerts for when the number of healthy hosts is less than expected. It's possible that this has been happening on a much longer term and might explain some of our editor stability issues.

I've done some initial digging in the ephemeral CloudWatch logs for killed aha-faye-app tasks. There's something in the faye-redis-sharded-node package that caused the container to die when an undefined client id is encountered.

We should add some diagnostic logging to try and find out why this is happening, and write to Sentry so we get eyes on this proactively.

We should also return a default shard so aha-faye-app doesn't die while we continue to diagnose the root cause.


Changes: Add diagnostic logging to the sharding code.

Also return a Redis client from the default shard instead of killing the process.