### PR TITLE
DEVOPS-1747: Fix error when missing clientId

### DIFF
--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -414,10 +414,11 @@ Engine.prototype = {
     finally {
       console.info("Returning default shard's Redis");
       const shards = this._shardManagers[0]._shards;
-      if ((shards?.length || 0) === 0)
+      const keys = Object.keys(shards);
+      if (keys.length === 0)
         throw "Unable to find default shard"; // Safety check: this should never happen
 
-      return shards[Object.keys(shards)[0]].redis;
+      return shards[keys[0]].redis;
     }
   }
 };

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -407,14 +407,14 @@ Engine.prototype = {
 
     // Try to get more information on when/why we're missing clientId by dumping the context
     try {
-      const msg = `clientId is undefined, context is: ${context}`;
+      const msg = `clientId is undefined, context is: ${JSON.stringify(context)}`;
       console.warn(msg);
       sentry.logError(new Error(msg));
     }
     finally {
       console.info("Returning default shard's Redis");
       const shards = this._shardManagers[0]._shards;
-      if (shards?.length || 0 === 0)
+      if ((shards?.length || 0) === 0)
         throw "Unable to find default shard"; // Safety check: this should never happen
 
       return shards[Object.keys(shards)[0]].redis;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description":"Redis backend engine for Faye with support for sharding",
   "author":"Myspace",
   "keywords":["faye", "faye-redis", "pubsub", "bayeux"],
-  "version":"0.2.7",
+  "version":"0.2.8",
   "engines":{
     "node":">=0.4.0"
   },


### PR DESCRIPTION
My previous PR https://github.com/aha-app/faye-redis-sharded-node/pull/6 wasn't correctly checking for the default shard, so aha-faye-app tasks were still being killed when the clientId was missing. Use some parentheses to force the desired order of operations.


Changes: Fix default shard lookup. Also format context better.

Fixes AHA-NODE-RQ

* [Sentry error](https://aha-labs-inc.sentry.io/issues/3944649861/events/910be03c5aa14da185804e04a1ae0244/?project=1211501)