### PR TITLE
DEVOPS-2099: Move client notify into promises to not lock main thread.

### DIFF
--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -320,6 +320,10 @@ Engine.prototype = {
       }, Promise.resolve()).finally(() => {
         const end = new Date();
         console.log(`[notify] Notified ${clientIds.length} clients in ${end - start}ms`);
+        if (clientIds.length > 10) {
+          const clientIdsUnique = [...new Set(clientIds)];
+          console.log(`[notify] ${clientIdsUnique.length} unique clients`);
+        }
       });
     };
 

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -324,7 +324,7 @@ Engine.prototype = {
         });
       }, Promise.resolve()).finally(() => {
         const end = new Date();
-        if (clientIds.length > 100) {
+        if (clientIds.length > 100 || clientIdsFiltered.length !== clientIds.length) {
           console.warn(`[notify] Notified ${clientIdsFiltered.length} unique clients (${clientIds.length} received) clients in ${end - start}ms`);
         }
       });

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -143,6 +143,10 @@ Engine.prototype = {
   },
 
   clientExists: function (clientId, callback, context) {
+    if (!clientId) {
+      return callback.call(context, false);
+    }
+
     var cutoff = new Date().getTime() - (1000 * 1.6 * this._server.timeout);
 
     // var redis = this._getShard(clientId).redis;

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -294,7 +294,7 @@ Engine.prototype = {
         return;
       }
 
-      const processNotification = (clientId) => {
+      const processNotification = async (clientId) => {
         const shard = self._getShard(clientId, shardManager);
         const redis = shard.redis;
         self._server.debug('Queueing for client ?: ?', clientId, message);
@@ -311,8 +311,8 @@ Engine.prototype = {
 
       const start = new Date();
       clientIds.reduce((promiseChain, clientId) => {
-        return promiseChain.then(() => {
-          processNotification(clientId);
+        return promiseChain.then(async () => {
+          await processNotification(clientId);
         });
       }, Promise.resolve()).finally(() => {
         const end = new Date();

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -289,20 +289,34 @@ Engine.prototype = {
         return self._ns + '/channels' + c;
       });
 
-    var notify = function (error, clients) {
-      if (error) return;
+    var notify = function (error, clientIds) {
+      if (error) {
+        return;
+      }
 
-      clients.forEach(function (clientId) {
-        var shard = self._getShard(clientId, shardManager),
-          redis = shard.redis;
+      const processNotification = (clientId) => {
+        const shard = self._getShard(clientId, shardManager);
+        const redis = shard.redis;
         self._server.debug('Queueing for client ?: ?', clientId, message);
-        redis.rpush(self._ns + '/clients/' + clientId + '/messages', jsonMessage, function (err, result) {
-          redis.publish(self._ns + '/' + clientId + '/notify', clientId);
+        redis.rpush(`${self._ns}/clients/${clientId}/messages}`, jsonMessage, function (err, result) {
+          redis.publish(`${self._ns}/${clientId}/notify`, clientId);
           self._server.debug('Published for client ? - ? - to server ?', clientId, message, shard.shardName);
         });
         self.clientExists(clientId, function(exists) {
-          if (!exists) redis.del(self._ns + '/clients/' + clientId + '/messages');
+          if (!exists) {
+            redis.del(`${self._ns}/clients/${clientId}/messages`);
+          }
         });
+      };
+
+      const start = new Date();
+      clientIds.reduce((promiseChain, clientId) => {
+        return promiseChain.then(() => {
+          processNotification(clientId);
+        });
+      }, Promise.resolve()).finally(() => {
+        const end = new Date();
+        console.log(`[notify] Notified ${clientIds.length} clients in ${end - start}ms`);
       });
     };
 

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -144,14 +144,12 @@ Engine.prototype = {
 
   clientExists: function (clientId, callback, context) {
     if (!clientId) {
+      // We should not be receiving undefined clientId's, but
+      // just in case, don't error out. Instead, return false.
       return callback.call(context, false);
     }
 
     var cutoff = new Date().getTime() - (1000 * 1.6 * this._server.timeout);
-
-    // var redis = this._getShard(clientId).redis;
-    // Replace the original code above with something more robust
-    // and that provides more info when clientId is undefined
     var redis = this._getRedis(clientId, context);
 
     redis.zscore(this._ns + '/clients', clientId, function (error, score) {

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -294,7 +294,7 @@ Engine.prototype = {
         return;
       }
 
-      const processNotification = async (clientId) => {
+      const processNotification = (clientId) => {
         const shard = self._getShard(clientId, shardManager);
         const redis = shard.redis;
         self._server.debug('Queueing for client ?: ?', clientId, message);
@@ -311,8 +311,11 @@ Engine.prototype = {
 
       const start = new Date();
       clientIds.reduce((promiseChain, clientId) => {
-        return promiseChain.then(async () => {
-          await processNotification(clientId);
+        return promiseChain.then(() => {
+          return new Promise(resolve => {
+            processNotification(clientId);
+            resolve();
+          });
         });
       }, Promise.resolve()).finally(() => {
         const end = new Date();

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -314,7 +314,7 @@ Engine.prototype = {
         return promiseChain.then(() => {
           return new Promise(resolve => {
             processNotification(clientId);
-            resolve();
+            setImmediate(resolve);
           });
         });
       }, Promise.resolve()).finally(() => {

--- a/lib/faye-redis-sharded.js
+++ b/lib/faye-redis-sharded.js
@@ -310,7 +310,8 @@ Engine.prototype = {
       };
 
       const start = new Date();
-      clientIds.reduce((promiseChain, clientId) => {
+      const clientIdsFiltered = [...new Set(clientIds)].filter(x => x); // remove nulls/duplicates
+      clientIdsFiltered.reduce((promiseChain, clientId) => {
         return promiseChain.then(() => {
           return new Promise(resolve => {
             processNotification(clientId);
@@ -319,10 +320,8 @@ Engine.prototype = {
         });
       }, Promise.resolve()).finally(() => {
         const end = new Date();
-        console.log(`[notify] Notified ${clientIds.length} clients in ${end - start}ms`);
-        if (clientIds.length > 10) {
-          const clientIdsUnique = [...new Set(clientIds)];
-          console.log(`[notify] ${clientIdsUnique.length} unique clients`);
+        if (clientIds.length > 100) {
+          console.warn(`[notify] Notified ${clientIdsFiltered.length} unique clients (${clientIds.length} received) clients in ${end - start}ms`);
         }
       });
     };


### PR DESCRIPTION
This is a tactical fix to address main thread issue locking in [aha-app/aha-faye-app](https://github.com/aha-app/aha-faye-app). Periodically faye will need to send a notification to a large number of subscribers. The existing code processes the Redis calls and publish events synchronously, and when a large list of client IDs arrives, this loop also causes the main thread memory to balloon. In some cases, the container will run out of memory before the notification tasks are completed (this is the minority of the time), but most other times freezes the main thread, preventing websocket or HTTP requests from processing for several seconds which [can](https://ahasupport.zendesk.com/agent/tickets/897189) lead to a degraded user experience. 

The updated version processes them one at a time over subsequent event loops, preventing the frozen thread and memory ballooning issues. This is likely slower than ideal, but prevents the container exits and stops the degraded user experience. This package is due for some attention. This function could benefit from an updated [redis/node-redis](https://github.com/redis/node-redis) package, which now supports the use of promises, which would gain better parallelization for the Redis calls. 

Additionally, someone more expert than I with Redis may be able to help make this function more efficient if it is possible to queue or batch some of these operations. 

